### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "project-require",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Allows to require project files as absolute paths, relative to the root of your node project.",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {},
   "scripts": {
-    "install": "mkdir -p node_modules/project-require && cp index.js node_modules/project-require/",
     "test": "npm install && node test.js"
   },
   "repository": {


### PR DESCRIPTION
Remove unneeded install script.

Not sure why, but your install creates a sub node_modules folder in the module folder and copies the code there, but you still use the original version out of the project-requires folder.  I noticed this when a person on our team who develops on a PC was having issue with the install script. 
