### PR TITLE
Update to make project platform independant. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports.thru = require;
 // and replace it with absolute path
 function pretendRequire(file)
 {
+    file = path.normalize(file)
   if (file && file.substr(0, 1) == path.sep)
   {
     file = path.join(projectPath, file.substr(1));
@@ -38,5 +39,5 @@ function projectPathGetterSetter(newPath)
 // that contains current module
 function projectPathDefault()
 {
-  return path.dirname(module.id).split(path.sep + 'node_modules' + path.sep, 2)[0];
+  return path.dirname(module.id).split(path.normalize('/node_modules/'), 2)[0];
 }

--- a/index.js
+++ b/index.js
@@ -38,5 +38,5 @@ function projectPathGetterSetter(newPath)
 // that contains current module
 function projectPathDefault()
 {
-  return path.dirname(module.id).split('/node_modules/', 2)[0];
+  return path.dirname(module.id).split(path.sep + 'node_modules' + path.sep, 2)[0];
 }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports.thru = require;
 // and replace it with absolute path
 function pretendRequire(file)
 {
-  if (file && file.substr(0, 1) == '/')
+  if (file && file.substr(0, 1) == path.sep)
   {
     file = path.join(projectPath, file.substr(1));
   }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "project-require",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Allows to require project files as absolute paths, relative to the root of your node project.",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {},
   "scripts": {
-    "install": "mkdir -p node_modules/project-require && cp index.js node_modules/project-require/",
     "test": "npm install && node test.js"
   },
   "repository": {

--- a/test.js
+++ b/test.js
@@ -1,19 +1,21 @@
-var project = 'project-require'
-  , require = require(project)
-  ;
+var project = 'project-require',
+    projectFile = './index.js'
+    , require = require(projectFile);
 
 // check default behavior
 console.assert(require('/package.json').name == project);
 
 // check custom path
-require.projectPath(__dirname+'/node_modules/'+project);
-console.assert(require('/../../package.json').name == project);
+require.projectPath(__dirname + '/index.js');
+console.assert(require('/../package.json').name == project);
 
 // check regular modules
-console.assert(typeof require(project).projectPath == 'function');
+console.assert(typeof require(projectFile).projectPath == 'function');
 
 // check built-in modules
 console.assert(typeof require('path').join == 'function');
 
 // check passing through
 console.assert(require.thru(process.cwd() + '/package.json').name == project);
+
+return 0;


### PR DESCRIPTION
Previously, the install routine mimicked the actual NPM install routine. However, due to differences in platforms, command like cp and mkdir -p do not run on windows platforms.  It appears the reason for the install script was to allow testing.  I've updated the package.json as well as the tests to no longer require this feature.
